### PR TITLE
limited_source_no_throw.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ This project is released under the [Apache License 2.0](http://www.apache.org/li
 Changelog
 ---------
 
+**2018-10-17**
+
+ * version 1.2.11
+ * Changed limited source behaviour. `sl::io::limited_source` limits the number of bytes
+ * read through it and returns EOF on threshold exceed
+
 **2018-06-20**
 
  * version 1.2.10

--- a/include/staticlib/io/limited_source.hpp
+++ b/include/staticlib/io/limited_source.hpp
@@ -38,7 +38,7 @@ namespace io {
 
 /**
  * Source wrapper that limits the number of bytes read through it
- * and throws "io_exception" on threshold exceed
+ * and returns EOF on threshold exceed
  */
 template<typename Source>
 class limited_source {

--- a/test/limited_source_test.cpp
+++ b/test/limited_source_test.cpp
@@ -39,9 +39,15 @@ void test_limit() {
     slassert(throws_exc([&src] { src.read({nullptr, 4}); }));
     slassert(2 == read);
     slassert(2 == src.get_count());
-    slassert(throws_exc([&src] { src.read({nullptr, 2}); }));
-    slassert(!throws_exc([&src, &arr] { src.read({arr.data(), 1}); }));
-    slassert(throws_exc([&src, &arr] { src.read({arr.data(), 1}); }));
+    slassert(1 == src.read({arr.data(), 2}));
+    slassert(std::char_traits<char>::eof() == src.read({arr.data(), 2}));
+    slassert(std::char_traits<char>::eof() == src.read({arr.data(), 1}));
+    slassert(3 == src.get_count());
+
+    auto second_try_src = sl::io::make_limited_source(two_bytes_at_once_source{"bar1"}, 3);
+    std::array<char, 4> second_array;
+    slassert(3 == second_try_src.read(second_array));
+    slassert(std::char_traits<char>::eof() == second_try_src.read({arr.data(), 1}));
 }
 
 int main() {

--- a/test/limited_source_test.cpp
+++ b/test/limited_source_test.cpp
@@ -44,10 +44,10 @@ void test_limit() {
     slassert(std::char_traits<char>::eof() == src.read({arr.data(), 1}));
     slassert(3 == src.get_count());
 
-    auto second_try_src = sl::io::make_limited_source(two_bytes_at_once_source{"bar1"}, 3);
-    std::array<char, 4> second_array;
-    slassert(3 == second_try_src.read(second_array));
-    slassert(std::char_traits<char>::eof() == second_try_src.read({arr.data(), 1}));
+    auto one_byte_src = sl::io::make_limited_source(two_bytes_at_once_source{"bar1"}, 1);
+    auto readed = one_byte_src.read({arr.data(), 2});
+    slassert(1 == readed);
+    slassert(std::char_traits<char>::eof() == one_byte_src.read({arr.data(), 1}));
 }
 
 int main() {


### PR DESCRIPTION
Limited source not throw on exceed limited bytes. Now read till limited_bytes and returns EOF after next try.